### PR TITLE
Fixed url function from duplicating url path

### DIFF
--- a/src/View/Helper/FileManagerHelper.php
+++ b/src/View/Helper/FileManagerHelper.php
@@ -1,9 +1,7 @@
 <?php
 namespace FileManager\View\Helper;
 
-use Cake\Routing\Router;
 use Cake\View\Helper;
-use Cake\View\View;
 
 /**
  * FileManager helper
@@ -26,25 +24,25 @@ class FileManagerHelper extends Helper
     public function url($item, $path)
     {
         if ($item['type'] === 'folder') {
-            $url = Router::url([
+            $url = [
                 'prefix' => 'admin',
                 'plugin' => 'FileManager',
                 'controller' => 'Manager',
                 'action' => 'index',
                 $path,
                 $item['name'],
-            ]);
+            ];
         }
 
         if ($item['type'] === 'file') {
-            $url = Router::url([
+            $url = [
                 'prefix' => 'admin',
                 'plugin' => 'FileManager',
                 'controller' => 'Manager',
                 'action' => 'view',
                 $path,
                 $item['name'],
-            ]);
+            ];
         }
 
         return $url;


### PR DESCRIPTION
Changed the url variable to use an array instead of Router::url. I was getting a full url path that was containing duplicate info. ie: project/app/project/app/file_manager/admin/manager/index/css instead of project/app/file_manager/admin/manager/index/css.

I also removed the unused view and router use statements.
